### PR TITLE
feat(async): Add control transfer

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -72,6 +72,18 @@ impl<'d> Transfer<'d> {
         Transfer::new(handle, endpoint, ::libusb::LIBUSB_TRANSFER_TYPE_INTERRUPT, buffer, timeout)
     }
 
+    pub fn endpoint(&self) -> u8 {
+        unsafe {
+            (*self.transfer).endpoint as u8
+        }
+    }
+
+    pub fn timeout(&self) -> Duration {
+        unsafe {
+            Duration::from_millis((*self.transfer).timeout as u64)
+        }
+    }
+
     /// Gets the status of a completed transfer.
     pub fn status(&self) -> TransferStatus {
         match unsafe { (*self.transfer).status } {


### PR DESCRIPTION
Add Transfer::control to create and submit control transfers.
In addition to the other method's parameters, it takes control setup
parameters to build the setup packet (first 8 bytes of the data buffer).
Therefore instead of `buffer: &mut [u8]` it takes `vec: &mut Vec<u8>`,
as we need to be able to prepend 8 bytes to it.
